### PR TITLE
Optimize date component calculation

### DIFF
--- a/Sources/LocalizedTimeAgo/LocalizedTimeAgo.swift
+++ b/Sources/LocalizedTimeAgo/LocalizedTimeAgo.swift
@@ -60,14 +60,13 @@ public extension Date {
 
     private var calendar: Calendar { return .current }
 
-    private var components: DateComponents {
+    private func components(relativeTo referenceDate: Date = Date()) -> DateComponents {
         let unitFlags = Set<Calendar.Component>([.second,.minute,.hour,.day,.weekOfYear,.month,.year])
-        let now = Date()
-        return calendar.dateComponents(unitFlags, from: self, to: now)
+        return calendar.dateComponents(unitFlags, from: self, to: referenceDate)
     }
 
-    func timeAgo(numericDates: Bool = false, numericTimes: Bool = false) -> String {
-        let components = self.components
+    func timeAgo(numericDates: Bool = false, numericTimes: Bool = false, relativeTo referenceDate: Date = Date()) -> String {
+        let components = self.components(relativeTo: referenceDate)
         if let year = components.year, year > 0 {
             if year >= 2 { return String(format: "%d years ago".adjustedKey(forValue: year).localized(), year) }
             return numericDates ? "1 year ago".localized() : "Last year".localized()
@@ -93,8 +92,8 @@ public extension Date {
         return numericTimes ? "1 second ago".localized() : "Just now".localized()
     }
 
-    func shortTimeAgo() -> String {
-        let components = self.components
+    func shortTimeAgo(relativeTo referenceDate: Date = Date()) -> String {
+        let components = self.components(relativeTo: referenceDate)
         if let year = components.year, year > 0 {
             return String(format: "%dy".localized(), year)
         } else if let month = components.month, month > 0 {

--- a/Sources/LocalizedTimeAgo/LocalizedTimeAgo.swift
+++ b/Sources/LocalizedTimeAgo/LocalizedTimeAgo.swift
@@ -67,6 +67,7 @@ public extension Date {
     }
 
     func timeAgo(numericDates: Bool = false, numericTimes: Bool = false) -> String {
+        let components = self.components
         if let year = components.year, year > 0 {
             if year >= 2 { return String(format: "%d years ago".adjustedKey(forValue: year).localized(), year) }
             return numericDates ? "1 year ago".localized() : "Last year".localized()
@@ -93,6 +94,7 @@ public extension Date {
     }
 
     func shortTimeAgo() -> String {
+        let components = self.components
         if let year = components.year, year > 0 {
             return String(format: "%dy".localized(), year)
         } else if let month = components.month, month > 0 {


### PR DESCRIPTION
Before this change, the date components were being calculated on each `if / else if` condition. This change removes the redundant calculation by making a local copy of the components before the `if / else if` conditions are reached.

This change also adds the option to specify the reference date, rather than limiting the reference date to `now`.