### PR TITLE
Short localization for Norwegian 🇳🇴

### DIFF
--- a/Resources/LocalizedTimeAgo.bundle/nb.lproj/LocalizedTimeAgo.strings
+++ b/Resources/LocalizedTimeAgo.bundle/nb.lproj/LocalizedTimeAgo.strings
@@ -123,3 +123,21 @@
 
 /* No comment provided by engineer. */
 "This year" = "Dette året";
+
+/* Week format for */
+"Mon" = "Ma.";
+"Tue" = "Ti.";
+"Wed" = "On.";
+"Thu" = "To.";
+"Fri" = "Fr.";
+"Sat" = "Lø.";
+"Sun" = "Sø.";
+
+/* Short format for */
+"%dy" = "%dår";  // year
+"%dM" = "%dMd."; // month
+"%dw" = "%duke"; // week
+"%dd" = "%ddg."; // day
+"%dh" = "%dt";   // hour
+"%dm" = "%dmin"; // minute
+"%ds" = "%ds";   // second

--- a/Resources/LocalizedTimeAgo.bundle/nb.lproj/LocalizedTimeAgo.strings
+++ b/Resources/LocalizedTimeAgo.bundle/nb.lproj/LocalizedTimeAgo.strings
@@ -135,7 +135,7 @@
 
 /* Short format for */
 "%dy" = "%dår";  // year
-"%dM" = "%dMd."; // month
+"%dM" = "%dmd."; // month
 "%dw" = "%duke"; // week
 "%dd" = "%ddg."; // day
 "%dh" = "%dt";   // hour


### PR DESCRIPTION
added short localization for Norwegian

[Source](http://www.sprakradet.no/sprakhjelp/Skriveregler/Forkortinger/)